### PR TITLE
fix refreshing behavior

### DIFF
--- a/Classes/UIScrollView+BottomRefreshControl.m
+++ b/Classes/UIScrollView+BottomRefreshControl.m
@@ -343,8 +343,8 @@ const CGFloat kMinRefershTime = 0.5;
 
     self.brc_context.beginRefreshingDate = [NSDate date];
 
+    [self.bottomRefreshControl beginRefreshing];
     [self.bottomRefreshControl sendActionsForControlEvents:UIControlEventValueChanged];
-    [self.bottomRefreshControl beginRefreshing];    
 
     if (!self.tracking && !self.brc_adjustBottomInset)
         [self brc_SetAdjustBottomInset:YES animated:YES];


### PR DESCRIPTION
This makes `CCBottomRefreshControl` behave more like system `UIRefreshControl`, which changes `refreshing` state before trigger the action.