### PR TITLE
Fix conflicts with setContentInsets

### DIFF
--- a/Classes/UIScrollView+BottomRefreshControl.m
+++ b/Classes/UIScrollView+BottomRefreshControl.m
@@ -161,7 +161,8 @@ const CGFloat kMinRefershTime = 0.5;
         
     [self brc_setContentInset:insets];
     
-    [self setNeedsUpdateConstraints];
+    if (self.brc_adjustBottomInset)
+        [self setNeedsUpdateConstraints];
 }
 
 - (UIEdgeInsets)brc_contentInset {


### PR DESCRIPTION
We have some conflicts with your library. We noticed that `brc_setContentInset` modify the default behaviour for all the `UIScrollView` instances, not only for those which have a `bottomRefreshControl`.

This PR modify the behaviour for `UIScrollView` without `bottomRefreshControl` to just call `super`